### PR TITLE
Allow users to change their password

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -6,6 +6,9 @@ type RegisterChallengeResponse = Awaited<ReturnType<ReturnType<typeof opaque>["e
 type LoginChallengeResponse = Awaited<ReturnType<ReturnType<typeof opaque>["endpoints"]["getLoginChallenge"]>>
 type RegisterComplete = Awaited<ReturnType<ReturnType<typeof opaque>["endpoints"]["completeRegistration"]>>
 type LoginComplete = Awaited<ReturnType<ReturnType<typeof opaque>["endpoints"]["completeLogin"]>>
+type ChangePasswordChallengeResponse = Awaited<ReturnType<ReturnType<typeof opaque>["endpoints"]["getChangePasswordChallenge"]>>
+type VerifyCurrentPasswordResponse = Awaited<ReturnType<ReturnType<typeof opaque>["endpoints"]["verifyCurrentPassword"]>>
+type CompleteChangePasswordResponse = Awaited<ReturnType<ReturnType<typeof opaque>["endpoints"]["completeChangePassword"]>>
 
 export const opaqueClient = () => {
 	return {

--- a/src/client.ts
+++ b/src/client.ts
@@ -98,6 +98,79 @@ export const opaqueClient = () => {
 							},
 						});
 					}
+				},
+				changePassword: async ({ currentPassword, newPassword }: {
+					currentPassword: string;
+					newPassword: string;
+				}) => {
+					await ready;
+
+					// Step 1: Start login with current password to verify it
+					const { clientLoginState, startLoginRequest } = client.startLogin({
+						password: currentPassword,
+					});
+
+					const challengeResponse = await $fetch<ChangePasswordChallengeResponse>("/change-password/opaque/challenge", {
+						method: "POST",
+						body: {
+							loginRequest: startLoginRequest,
+						},
+					});
+
+					if (!challengeResponse.data || !challengeResponse.data.challenge) {
+						return { data: null, error: challengeResponse.error || { message: "Failed to get password change challenge" } };
+					}
+
+					const { challenge: loginResponse, state: encryptedServerState } = challengeResponse.data;
+
+					// Complete login with current password
+					const loginAttempt = client.finishLogin({
+						password: currentPassword,
+						clientLoginState,
+						loginResponse,
+					});
+
+					if (!loginAttempt) {
+						return { data: null, error: { message: "Current password verification failed" } };
+					}
+
+					const { finishLoginRequest: loginResult } = loginAttempt;
+
+					// Step 2: Start registration with new password
+					const { clientRegistrationState, registrationRequest } = client.startRegistration({
+						password: newPassword,
+					});
+
+					// Verify current password and get registration challenge for new password
+					const verifyResponse = await $fetch<VerifyCurrentPasswordResponse>("/change-password/opaque/verify", {
+						method: "POST",
+						body: {
+							loginResult,
+							encryptedServerState,
+							registrationRequest,
+						},
+					});
+
+					if (!verifyResponse.data || !verifyResponse.data.verified || !verifyResponse.data.challenge) {
+						return { data: null, error: verifyResponse.error || { message: "Current password verification failed" } };
+					}
+
+					const { challenge: registrationResponse } = verifyResponse.data;
+
+					// Step 3: Complete registration with new password
+					const { registrationRecord } = client.finishRegistration({
+						clientRegistrationState,
+						password: newPassword,
+						registrationResponse,
+					});
+
+					// Complete password change
+					return await $fetch<CompleteChangePasswordResponse>("/change-password/opaque/complete", {
+						method: "POST",
+						body: {
+							registrationRecord,
+						},
+					});
 				}
 			}
 		},

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { ready, server } from "@serenity-kit/opaque";
 import { APIError, type BetterAuthPlugin, type User } from "better-auth";
-import { createAuthEndpoint } from "better-auth/api";
+import { createAuthEndpoint, sessionMiddleware } from "better-auth/api";
 import { setSessionCookie } from "better-auth/cookies";
 import { generateRandomString } from "better-auth/crypto";
 import * as z from "zod";
@@ -315,6 +315,185 @@ export const opaque = (options?: OpaqueOptions) => {
 						user: {
 							id: user.id,
 						},
+					});
+				},
+			),
+
+			// Password Change Flow - Step 1: Verify current password
+			getChangePasswordChallenge: createAuthEndpoint(
+				"/change-password/opaque/challenge",
+				{
+					method: "POST",
+					body: z.object({
+						loginRequest: z.string().base64url(),
+					}),
+					use: [sessionMiddleware],
+				},
+				async (ctx) => {
+					const { loginRequest } = ctx.body;
+
+					if (!ctx.context.session) {
+						throw new APIError("UNAUTHORIZED", {
+							message: "You must be logged in to change your password",
+						});
+					}
+
+					const { user } = ctx.context.session;
+
+					validateBase64Length(
+						loginRequest,
+						LOGIN_REQUEST_LENGTH,
+						"login request",
+					);
+
+					const opaqueAccount = await findOpaqueAccount(ctx, user.id);
+
+					if (!opaqueAccount || !opaqueAccount.registrationRecord) {
+						throw new APIError("BAD_REQUEST", {
+							message: "No OPAQUE account found for this user",
+						});
+					}
+
+					const { loginResponse, serverLoginState } = server.startLogin({
+						userIdentifier: user.email,
+						startLoginRequest: loginRequest,
+						serverSetup: OPAQUE_SERVER_KEY,
+						registrationRecord: opaqueAccount.registrationRecord,
+					});
+
+					const encryptedServerState = await encryptServerLoginState(
+						serverLoginState,
+						ctx.context.secret,
+						user,
+					);
+
+					return { challenge: loginResponse, state: encryptedServerState };
+				},
+			),
+
+			// Password Change Flow - Step 2: Verify current password and get new password registration challenge
+			verifyCurrentPassword: createAuthEndpoint(
+				"/change-password/opaque/verify",
+				{
+					method: "POST",
+					body: z.object({
+						loginResult: z.string().base64url(),
+						encryptedServerState: z.string(),
+						registrationRequest: z.string().base64url(),
+					}),
+					use: [sessionMiddleware],
+				},
+				async (ctx) => {
+					const { loginResult, encryptedServerState, registrationRequest } = ctx.body;
+
+					if (!ctx.context.session) {
+						throw new APIError("UNAUTHORIZED", {
+							message: "You must be logged in to change your password",
+						});
+					}
+
+					const sessionUser = ctx.context.session.user;
+
+					validateBase64Length(
+						registrationRequest,
+						REGISTRATION_REQUEST_LENGTH,
+						"registration request",
+					);
+
+					let serverLoginState: string;
+					let user: User | null;
+
+					try {
+						({ serverLoginState, user } = await decryptServerLoginState(
+							encryptedServerState,
+							ctx.context.secret,
+						));
+					} catch {
+						throw new APIError("BAD_REQUEST", {
+							message: "Invalid login state",
+						});
+					}
+
+					// Verify the user in the encrypted state matches the session user
+					if (!user || user.id !== sessionUser.id) {
+						throw new APIError("UNAUTHORIZED", {
+							message: "Password verification failed",
+						});
+					}
+
+					const { sessionKey } = server.finishLogin({
+						finishLoginRequest: loginResult,
+						serverLoginState: serverLoginState,
+					});
+
+					if (!sessionKey) {
+						throw new APIError("UNAUTHORIZED", {
+							message: "Current password verification failed",
+						});
+					}
+
+					// Current password verified, now create registration challenge for new password
+					const { registrationResponse } = server.createRegistrationResponse({
+						userIdentifier: sessionUser.email,
+						registrationRequest,
+						serverSetup: OPAQUE_SERVER_KEY,
+					});
+
+					return { verified: true, challenge: registrationResponse };
+				},
+			),
+
+			// Password Change Flow - Step 3: Complete password change with new registration record
+			completeChangePassword: createAuthEndpoint(
+				"/change-password/opaque/complete",
+				{
+					method: "POST",
+					body: z.object({
+						registrationRecord: z.string().base64url(),
+					}),
+					use: [sessionMiddleware],
+				},
+				async (ctx) => {
+					const { registrationRecord } = ctx.body;
+
+					if (!ctx.context.session) {
+						throw new APIError("UNAUTHORIZED", {
+							message: "You must be logged in to change your password",
+						});
+					}
+
+					const user = ctx.context.session.user;
+
+					validateBase64LengthRange(
+						registrationRecord,
+						REGISTRATION_RECORD_MIN_LENGTH,
+						REGISTRATION_RECORD_MAX_LENGTH,
+						"registration record",
+					);
+
+					const opaqueAccount = await findOpaqueAccount(ctx, user.id);
+
+					if (!opaqueAccount) {
+						throw new APIError("BAD_REQUEST", {
+							message: "No OPAQUE account found for this user",
+						});
+					}
+
+					// Update the registration record with the new password
+					await ctx.context.internalAdapter.updateAccount(
+						opaqueAccount.id,
+						{
+							// @ts-ignore Ideally there should be a generic passed to updateAccount
+							// To allow the type but that's not the case, fix later with update method
+							// directly?
+							registrationRecord,
+							updatedAt: new Date(),
+						},
+					);
+
+					return ctx.json({
+						success: true,
+						message: "Password changed successfully",
 					});
 				},
 			),


### PR DESCRIPTION
FIxes #1

## Summary by Sourcery

Add a multi-step OPAQUE-based password change flow requiring an authenticated session and current password verification before updating the stored registration record.

New Features:
- Introduce authenticated endpoints to initiate an OPAQUE password change challenge, verify the current password, and complete the password change by storing a new registration record.
- Expose corresponding client-side response types for the new password change endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure password change functionality requiring current password verification through a multi-step process before updating to a new password.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->