### PR TITLE
Allow changing passwords

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "better-auth-opaque",

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,6 +6,8 @@ type RegisterChallengeResponse = Awaited<ReturnType<ReturnType<typeof opaque>["e
 type LoginChallengeResponse = Awaited<ReturnType<ReturnType<typeof opaque>["endpoints"]["getLoginChallenge"]>>
 type RegisterComplete = Awaited<ReturnType<ReturnType<typeof opaque>["endpoints"]["completeRegistration"]>>
 type LoginComplete = Awaited<ReturnType<ReturnType<typeof opaque>["endpoints"]["completeLogin"]>>
+type ChangePasswordChallengeResponse = Awaited<ReturnType<ReturnType<typeof opaque>["endpoints"]["getChangePasswordChallenge"]>>
+type ChangePasswordComplete = Awaited<ReturnType<ReturnType<typeof opaque>["endpoints"]["completeChangePassword"]>>
 
 export const opaqueClient = () => {
 	return {
@@ -95,6 +97,67 @@ export const opaqueClient = () => {
 							},
 						});
 					}
+				},
+				changePassword: async ({ currentPassword, newPassword }: {
+					currentPassword: string;
+					newPassword: string;
+				}) => {
+					await ready;
+
+					// Start login flow with current password
+					const { clientLoginState, startLoginRequest } = client.startLogin({
+						password: currentPassword,
+					});
+
+					// Start registration flow with new password
+					const { clientRegistrationState, registrationRequest } = client.startRegistration({
+						password: newPassword,
+					});
+
+					// Get challenges for both operations
+					const challengeResponse = await $fetch<ChangePasswordChallengeResponse>("/opaque/changePassword/challenge", {
+						method: "POST",
+						body: {
+							loginRequest: startLoginRequest,
+							registrationRequest,
+						},
+					});
+
+					if (!challengeResponse.data || !challengeResponse.data.loginChallenge || !challengeResponse.data.registrationChallenge) {
+						return { data: null, error: { message: "Failed to get change password challenge" } };
+					}
+
+					const { loginChallenge, registrationChallenge, state: encryptedServerState } = challengeResponse.data;
+
+					// Finish login with current password
+					const loginAttempt = client.finishLogin({
+						password: currentPassword,
+						clientLoginState,
+						loginResponse: loginChallenge,
+					});
+
+					if (!loginAttempt) {
+						return { data: null, error: { message: "Current password is incorrect" } };
+					}
+
+					const { finishLoginRequest: loginResult } = loginAttempt;
+
+					// Finish registration with new password
+					const { registrationRecord } = client.finishRegistration({
+						clientRegistrationState,
+						password: newPassword,
+						registrationResponse: registrationChallenge,
+					});
+
+					// Complete the change password operation
+					return await $fetch<ChangePasswordComplete>("/opaque/changePassword/complete", {
+						method: "POST",
+						body: {
+							loginResult,
+							registrationRecord,
+							encryptedServerState,
+						},
+					});
 				}
 			}
 		},

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { ready, server } from "@serenity-kit/opaque";
 import { APIError, type BetterAuthPlugin, type User } from "better-auth";
-import { createAuthEndpoint } from "better-auth/api";
+import { createAuthEndpoint, sessionMiddleware } from "better-auth/api";
 import { setSessionCookie } from "better-auth/cookies";
 import { generateRandomString } from "better-auth/crypto";
 import * as z from "zod";
@@ -315,6 +315,158 @@ export const opaque = (options?: OpaqueOptions) => {
 						user: {
 							id: user.id,
 						},
+					});
+				},
+			),
+
+			getChangePasswordChallenge: createAuthEndpoint(
+				"/opaque/changePassword/challenge",
+				{
+					method: "POST",
+					requireHeaders: true,
+					body: z.object({
+						loginRequest: z.string().base64url(),
+						registrationRequest: z.string().base64url(),
+					}),
+					use: [sessionMiddleware]
+				},
+				async (ctx) => {
+					const { loginRequest, registrationRequest } = ctx.body;
+					const email = ctx.context.session.user.email;
+					validateBase64Length(
+						loginRequest,
+						LOGIN_REQUEST_LENGTH,
+						"login request",
+					);
+					validateBase64Length(
+						registrationRequest,
+						REGISTRATION_REQUEST_LENGTH,
+						"registration request",
+					);
+
+					const startTime = performance.now();
+
+					const opaqueAccount = await findOpaqueAccount(ctx, ctx.context.session.user.id);
+					if (!opaqueAccount?.registrationRecord) {
+						throw new APIError("BAD_REQUEST", {
+							message: "No OPAQUE account found",
+						});
+					}
+
+					// Step 1: Verify old password with login challenge
+					const { loginResponse, serverLoginState } = server.startLogin({
+						userIdentifier: email,
+						startLoginRequest: loginRequest,
+						serverSetup: OPAQUE_SERVER_KEY,
+						registrationRecord: opaqueAccount.registrationRecord,
+					});
+
+					// Step 2: Generate new password challenge
+					const { registrationResponse } = server.createRegistrationResponse({
+						userIdentifier: email,
+						registrationRequest,
+						serverSetup: OPAQUE_SERVER_KEY,
+					});
+
+					// Encrypt the server login state for verification in complete step
+					const encryptedServerState = await encryptServerLoginState(
+						serverLoginState,
+						ctx.context.secret,
+						ctx.context.session.user,
+					);
+
+					ctx.context.logger.debug(
+						`[CHANGE_PASSWORD] Total time: ${(performance.now() - startTime).toFixed(2)}ms`,
+					);
+
+					return {
+						loginChallenge: loginResponse,
+						registrationChallenge: registrationResponse,
+						state: encryptedServerState,
+					};
+				},
+			),
+
+			completeChangePassword: createAuthEndpoint(
+				"/opaque/changePassword/complete",
+				{
+					method: "POST",
+					requireHeaders: true,
+					body: z.object({
+						loginResult: z.string().base64url(),
+						registrationRecord: z.string().base64url(),
+						encryptedServerState: z.string(),
+					}),
+					use: [sessionMiddleware]
+				},
+				async (ctx) => {
+					const { loginResult, registrationRecord, encryptedServerState } =
+						ctx.body;
+
+					validateBase64LengthRange(
+						registrationRecord,
+						REGISTRATION_RECORD_MIN_LENGTH,
+						REGISTRATION_RECORD_MAX_LENGTH,
+						"registration record",
+					);
+
+					let serverLoginState: string;
+					let user: User | null;
+
+					try {
+						({ serverLoginState, user } = await decryptServerLoginState(
+							encryptedServerState,
+							ctx.context.secret,
+						));
+					} catch {
+						throw new APIError("BAD_REQUEST", {
+							message: "Invalid login state",
+						});
+					}
+
+					// CRITICAL: Verify decrypted user matches the authenticated session user
+					// An attacher could steal this from any other request if we didn't verify
+					if (!user || user.id !== ctx.context.session.user.id) {
+						throw new APIError("UNAUTHORIZED", {
+							message: "User mismatch",
+						});
+					}
+
+					// Verify the old password
+					const { sessionKey } = server.finishLogin({
+						finishLoginRequest: loginResult,
+						serverLoginState: serverLoginState,
+					});
+
+					if (!sessionKey) {
+						throw new APIError("UNAUTHORIZED", {
+							message: "Invalid current password",
+						});
+					}
+
+					// Old password verified, now update to new password
+					const opaqueAccount = await findOpaqueAccount(ctx, ctx.context.session.user.id);
+					if (!opaqueAccount) {
+						throw new APIError("BAD_REQUEST", {
+							message: "No OPAQUE account found",
+						});
+					}
+
+					await ctx.context.internalAdapter.updateAccount(
+						opaqueAccount.id,
+						{
+							registrationRecord,
+							updatedAt: new Date(),
+						} as Partial<typeof opaqueAccount>,
+					);
+
+					ctx.context.logger.debug(
+						`[CHANGE_PASSWORD] Password changed successfully for ${ctx.context.session.user.email.substring(0, 20)}...`,
+					);
+
+					return ctx.json({
+						success: true,
+						message: "Password changed successfully",
 					});
 				},
 			),

--- a/src/server.ts
+++ b/src/server.ts
@@ -346,19 +346,22 @@ export const opaque = (options?: OpaqueOptions) => {
 
 					const startTime = performance.now();
 
+					// Always perform OPAQUE operations to mitigate timing attacks
 					const opaqueAccount = await findOpaqueAccount(ctx, ctx.context.session.user.id);
+					let registrationRecord: string;
 					if (!opaqueAccount?.registrationRecord) {
-						throw new APIError("BAD_REQUEST", {
-							message: "No OPAQUE account found",
-						});
+						// Use dummy record if no OPAQUE account exists
+						registrationRecord = await createDummyRegistrationRecord();
+					} else {
+						registrationRecord = opaqueAccount.registrationRecord;
 					}
 
-					// Step 1: Verify old password with login challenge
+					// Step 1: Verify old password with login challenge (real or dummy)
 					const { loginResponse, serverLoginState } = server.startLogin({
 						userIdentifier: email,
 						startLoginRequest: loginRequest,
 						serverSetup: OPAQUE_SERVER_KEY,
-						registrationRecord: opaqueAccount.registrationRecord,
+						registrationRecord,
 					});
 
 					// Step 2: Generate new password challenge
@@ -409,7 +412,12 @@ export const opaque = (options?: OpaqueOptions) => {
 						REGISTRATION_RECORD_MAX_LENGTH,
 						"registration record",
 					);
-
+					validateBase64LengthRange(
+						registrationRecord,
+						REGISTRATION_RECORD_MIN_LENGTH,
+						REGISTRATION_RECORD_MAX_LENGTH,
+						"registration record",
+					)
 					let serverLoginState: string;
 					let user: User | null;
 
@@ -431,7 +439,12 @@ export const opaque = (options?: OpaqueOptions) => {
 							message: "User mismatch",
 						});
 					}
-
+					const opaqueAccount = await findOpaqueAccount(ctx, ctx.context.session.user.id);
+					if (!opaqueAccount) {
+						throw new APIError("BAD_REQUEST", {
+							message: "No OPAQUE account found",
+						});
+					}
 					// Verify the old password
 					const { sessionKey } = server.finishLogin({
 						finishLoginRequest: loginResult,
@@ -445,12 +458,6 @@ export const opaque = (options?: OpaqueOptions) => {
 					}
 
 					// Old password verified, now update to new password
-					const opaqueAccount = await findOpaqueAccount(ctx, ctx.context.session.user.id);
-					if (!opaqueAccount) {
-						throw new APIError("BAD_REQUEST", {
-							message: "No OPAQUE account found",
-						});
-					}
 
 					await ctx.context.internalAdapter.updateAccount(
 						opaqueAccount.id,
@@ -459,6 +466,8 @@ export const opaque = (options?: OpaqueOptions) => {
 							updatedAt: new Date(),
 						} as Partial<typeof opaqueAccount>,
 					);
+					// Invalidate all sessions
+					await ctx.context.internalAdapter.deleteSessions(user.id)
 
 					ctx.context.logger.debug(
 						`[CHANGE_PASSWORD] Password changed successfully for ${ctx.context.session.user.email.substring(0, 20)}...`,

--- a/src/server.ts
+++ b/src/server.ts
@@ -425,7 +425,7 @@ export const opaque = (options?: OpaqueOptions) => {
 					}
 
 					// CRITICAL: Verify decrypted user matches the authenticated session user
-					// An attacher could steal this from any other request if we didn't verify
+					// An attacker could steal this from any other request if we didn't verify
 					if (!user || user.id !== ctx.context.session.user.id) {
 						throw new APIError("UNAUTHORIZED", {
 							message: "User mismatch",


### PR DESCRIPTION
Feel free to audit this change and let me know if I messed up anywhere.

## Summary by Sourcery

Add backend and client support for changing a user's OPAQUE password after verifying their current password.

New Features:
- Introduce server endpoints to initiate and complete an authenticated OPAQUE password change flow.
- Expose a client-side changePassword helper that orchestrates the OPAQUE login and re-registration steps using the new endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can change passwords via a secure, session-bound two-step flow.
  * Client exposes a change-password action to initiate and complete the update.
  * Server adds endpoints to produce a combined change-password challenge and to finalize the change, validate current credentials, update the account, and invalidate existing sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->